### PR TITLE
fix flake8 command path

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,7 +76,7 @@ Ready to contribute? Here's how to set up `stackhut` for local development.
 
 5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
-    $ flake8 stackhut tests
+    $ flake8 stackhut_client tests
     $ python setup.py test
     $ tox
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean-test:
 	rm -fr htmlcov/
 
 lint:
-	flake8 stackhut tests
+	flake8 stackhut_client tests
 
 test:
 	python3 setup.py test


### PR DESCRIPTION
update `make lint` and CONTRIBUTING.rst with the correct path
for the client (was incorrectly pointing to `stackhut` instead of
`stackhut_client`)

`make lint` now works instead of throwing an error