### PR TITLE
add dev_requirements.txt file

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -67,6 +67,7 @@ Ready to contribute? Here's how to set up `stackhut` for local development.
     $ mkvirtualenv client-python
     $ cd client-python/
     $ python setup.py develop
+    $ pip3 install -r dev_requirements.txt
 
 4. Create a branch for local development::
 
@@ -79,8 +80,6 @@ Ready to contribute? Here's how to set up `stackhut` for local development.
     $ flake8 stackhut tests
     $ python setup.py test
     $ tox
-
-   To get flake8 and tox, just pip install them into your virtualenv.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,2 @@
+tox
+flake8


### PR DESCRIPTION
This PR could use some discussion - this is definitely a matter of preference, so feel free to reject if the idea of dev_requirements.txt rubs you the wrong way.


Add a single requirements file that can be pip installed instead of
listing libraries in the instruction blocks of CONTRIBUTING.rst.

Now all current and future python dev dependencies (aside from
virtualenvwrapper) can be handled with a single command.