### PR TITLE
add initial test coverage

### DIFF
--- a/tests/connection.py
+++ b/tests/connection.py
@@ -1,0 +1,38 @@
+from unittest import skip
+import stackhut_client
+from .test_helpers import BaseTest
+
+
+TEST_HOST_NOSCHEME = 'localhost:4001'
+
+
+class SimpleConnectionTest(BaseTest):
+    """
+    This is an extremely basic test that connects to a demo stackhut server.
+
+    Verifies that a connection can be made without issue or that the client
+    throws the correct errors.
+    """
+
+    def test_create_client(self):
+        """
+        Test that create_client returns a non-None
+        value without throwing an error.
+        """
+        client = self.create_client()
+        self.assertNotEqual(client, None)
+
+    def test_schemeless_host(self):
+        """
+        Verify host with no scheme throws a MissingSchema exception.
+        """
+        client = self.create_client(host=TEST_HOST_NOSCHEME)
+        MissingSchema = \
+            stackhut_client.client.requests.exceptions.MissingSchema
+        with self.assertRaises(MissingSchema):
+            client.Default.add(1, 2)
+
+    @skip('not implemented')
+    def test_invalid_host(self):
+        # TODO: specify how invalid hostname should be handled
+        self.fail('test not implemented')

--- a/tests/simple_integration.py
+++ b/tests/simple_integration.py
@@ -1,0 +1,19 @@
+from .test_helpers import BaseTest
+
+
+class SimpleIntegrationTest(BaseTest):
+    """
+    This is a super simple integration test that goes through
+    the entire lifecycle of connecting to an account, using a service,
+    and ensuring it correctly returns the result (as the correct type).
+    """
+
+    def test_run_service(self):
+        """
+        Verify that running the add service correctly runs and returns the
+        expected value.
+        """
+        for i in range(5):
+            x, y = i, i * i
+            result = self.client.Default.add(x, y)
+            self.assertEqual(x + y, result)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,88 @@
+from unittest import TestCase
+import logging
+import stackhut_client
+
+
+# uncomment the following line to enable verbose logging
+# logging.basicConfig(level=logging.DEBUG)
+
+
+TEST_USERNAME = 'stackhut'
+TEST_SERVICE = 'demo-python'
+TEST_HOST = None  # falls back to official server
+INVALID_HOST = 'not a valid hostname'
+
+use_local_server = False
+if use_local_server:
+    TEST_USERNAME = 'your-stackhut-username'
+    TEST_SERVICE = 'your-server-name'
+    TEST_HOST = 'http://localhost:4001'
+
+
+def create_client(username=None, service=None, host=None):
+    """
+    Creates a new client connection. Uses the given parameters or
+    falls back to the constants at this file.
+
+    Returns a new SHService
+    """
+
+    target_username = username or TEST_USERNAME
+    target_service = service or TEST_SERVICE
+    target_host = host or TEST_HOST
+
+    logging.debug(
+        'creating stackhut connection for %s %s at %s' % (
+            target_username,
+            target_service,
+            target_host
+        )
+    )
+
+    if target_host:
+        return stackhut_client.SHService(
+            target_username,
+            target_service,
+            host=target_host
+        )
+
+    return stackhut_client.SHService(
+        target_username,
+        target_service
+    )
+
+
+class BaseTest(TestCase):
+    """
+    A base test class to help reduce boilerplate connection code.
+
+    Includes a single `client` property that is created only once, then shared
+    across all tests. Subclasses of this test case can simply use `self.client`
+    without having to create a new connection every time.
+
+    Note that because all your tests can share the same connection you must
+    take care to ensure your tests do not rely on test ordering (or other tests
+    at all).
+
+    If a new connection is important to the test, the class also includes a
+    `create_client` method that accepts optional username, service, and host
+    and returns a new connection.
+
+    """
+
+    def create_client(self, username=None, service=None, host=None):
+        """
+        Returns a client created with the create_client function. Accepts
+        optional username, service, and host. If any are left out, the
+        test defaults from test_helpers.py will be used.
+        """
+        return create_client(username, service, host)
+
+    @property
+    def client(self):
+        return self.get_client()
+
+    def get_client(self):
+        if not hasattr(self, '_client'):
+            self._client = self.create_client()
+        return self._client


### PR DESCRIPTION
Another opinionated PR - you may want to replace with your own flavor of test setup.


`make test` now runs 4 tests, including coverage for creating a
connection, calling a service, and getting a response.

Also includes a flag for using a local server instead of the live demo
server.

TODO: the local server test options could be improved to be easier to use
- test command that specifies local
- optionally take config from environment instead of hand-editing file